### PR TITLE
Test showing bug with computed observable

### DIFF
--- a/lib/computedObservable/__tests__/createComputedObservable.test.ts
+++ b/lib/computedObservable/__tests__/createComputedObservable.test.ts
@@ -1,13 +1,38 @@
+import Observable from '../../Observable'
 import create from '../../observableValue/create'
 import getObserve from '../../observableValue/getObserve'
 import set from '../../observableValue/set'
+import Compute from '../Compute'
 import createComputedObservable from '../createComputedObservable'
 
 test('observable without initial get value', () => {
-  const internalObservable = create(0)
-  const observable = createComputedObservable(observe => observe(getObserve(internalObservable)))
-  const listener = jest.fn()
-  observable.addRemove.add(listener)
-  set(internalObservable, 1)
+  const internalObservable = create('initial')
+  const computedObservable = createComputedObservable(observe =>
+    observe(getObserve(internalObservable)))
+  let latestValue: any
+  const listener = jest.fn(() => {
+    latestValue = computedObservable.getValue()
+  })
+  computedObservable.addRemove.add(listener)
+  expect(computedObservable.getValue()).toBe('initial')
+  expect(listener).toBeCalledTimes(0)
+  set(internalObservable, 'updated')
   expect(listener).toBeCalledTimes(1)
+  expect(latestValue).toBe('updated')
+})
+
+test("getValue() is read-only doesn't re-observe observables", () => {
+  const internalObservable: Observable<unknown> = {
+    getValue: jest.fn(),
+    addRemove: { add: jest.fn(), remove: jest.fn() }
+  }
+  const compute: Compute<unknown> = observe => observe(internalObservable)
+  const mockFn = jest.fn(compute)
+  const computedObservable = createComputedObservable(mockFn)
+  expect(internalObservable.addRemove.add).toBeCalledTimes(0)
+  expect(internalObservable.addRemove.remove).toBeCalledTimes(0)
+
+  computedObservable.getValue()
+  expect(internalObservable.addRemove.add).toBeCalledTimes(0)
+  expect(internalObservable.addRemove.remove).toBeCalledTimes(0)
 })


### PR DESCRIPTION
Currently, calling `computedObservable.getValue()` could generate different internal observables, which messes things up.